### PR TITLE
(test) Add karma/mocha-chai, basic AppCtrl spec template [Closes #13]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,8 @@
     "angular-ui-router": "~0.2.15",
     "angular-material": "~0.11.4",
     "angularjs-geolocation": "~0.1.1",
-    "angular-typeahead": "~0.2.4"
+    "angular-typeahead": "~0.2.4",
+    "angular": "~1.4.7",
+    "angular-mocks": "~1.4.7"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,24 @@
 var gulp = require('gulp');
 var jshint = require('gulp-jshint');
+var Server = require('karma').Server;
 
 gulp.task('lint', function() {
   return gulp.src(['./server/**/*.js', './client/**/*.js', '!./client/lib/**/*.js', './*.js'])
     .pipe(jshint())
-    .pipe(jshint.reporter('default'));
+    .pipe(jshint.reporter('jshint-stylish'));
 });
+
+/**
+ * Run test once and exit
+ */
+gulp.task('test', function(done) {
+  new Server({
+    configFile: __dirname + '/karma.conf.js',
+    singleRun: true,
+  }, done).start();
+});
+
+gulp.task('check', ['lint', 'test']);
 
 gulp.task('default', function() {
   // place code for your default task here

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,64 @@
+// Karma configuration
+// Generated on Fri Oct 16 2015 18:21:34 GMT-0700 (PDT)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['mocha', 'chai'],
+
+    // list of files / patterns to load in the browser
+    files: [
+      'client/lib/angular/angular.js',
+      'client/lib/angular-animate/angular-animate.js',
+      'client/lib/angular-aria/angular-aria.js',
+      'client/lib/braintree-web/dist/braintree.js',
+      'client/lib/angular-material/angular-material.js',
+      'client/lib/angular-ui-router/release/angular-ui-router.js',
+      'client/lib/angularjs-geolocation/src/geolocation.js',
+      'client/lib/angular-mocks/angular-mocks.js',
+      'client/lib/angular-typeahead/angular-typeahead.js',
+      'client/*.js',
+      'spec/**/*.js',
+    ],
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['mocha'],
+
+    // web server port
+    port: 9876,
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: false,
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['PhantomJS'],
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,16 @@
     "node": "4.2.1"
   },
   "devDependencies": {
+    "chai": "^3.3.0",
     "gulp": "^3.9.0",
-    "gulp-jshint": "^1.11.2"
+    "gulp-jshint": "^1.11.2",
+    "jshint-stylish": "^2.0.1",
+    "karma": "^0.13.11",
+    "karma-chai": "^0.1.0",
+    "karma-mocha": "^0.2.0",
+    "karma-mocha-reporter": "^1.1.1",
+    "karma-phantomjs-launcher": "^0.2.1",
+    "mocha": "^2.3.3",
+    "phantomjs": "^1.9.18"
   }
 }

--- a/spec/client/AppCtrlSpec.js
+++ b/spec/client/AppCtrlSpec.js
@@ -1,0 +1,25 @@
+describe('AppCtrl', function () {
+
+  var controller, scope;
+  beforeEach(module('StarterApp'));
+  beforeEach(inject(function ($controller, $rootScope) {
+    scope = $rootScope.$new();
+    controller = $controller('AppCtrl', {
+      $scope: scope
+    });
+  }));
+
+  it('initializes a message to the scope', function () {
+    expect(scope.message).to.be.a('string');
+  });
+
+  it('initializes the correct message to the scope', function () {
+    expect(scope.message).to.equal('Please specify tip amount in the form below:');
+  });
+
+  // Sanity check
+  // it('fails on purpose sometimes', function() {
+  //   expect(scope.message).to.equal('hello');
+  // });
+
+});

--- a/spec/server/serverSpec.js
+++ b/spec/server/serverSpec.js
@@ -1,0 +1,3 @@
+describe('Server', function () {
+  
+});


### PR DESCRIPTION
- `gulp test` runs tests
- `gulp check` runs linter, then tests
- added dev dependencies: chai, jshint-stylish, karma, karma-chai,
  karma-mocha, karma-mocha-reporter, karma-phantomjs-launcher, mocha,
  phantomjs.
- added bower dependencies: angular-mocks
