### PR TITLE
(feat) Implement facebook login/signup in react-native [Closes #370]

### DIFF
--- a/tippus/android/app/build.gradle
+++ b/tippus/android/app/build.gradle
@@ -27,4 +27,5 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.facebook.react:react-native:0.13.+'
     compile project(':RNMaterialKit')
+    compile project(':react-native-facebook-login')
 }

--- a/tippus/android/app/src/main/AndroidManifest.xml
+++ b/tippus/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,18 @@
         </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+      <!--add FacebookActivity-->
+      <activity
+              android:name="com.facebook.FacebookActivity"
+              android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
+              android:label="@string/app_name"
+              android:theme="@android:style/Theme.Translucent.NoTitleBar"/>
+
+      <!--reference your fb_app_id-->
+      <meta-data
+              android:name="com.facebook.sdk.ApplicationId"
+              android:value="@string/fb_app_id"/>
+              
     </application>
 
 </manifest>

--- a/tippus/android/app/src/main/java/com/tippus/MainActivity.java
+++ b/tippus/android/app/src/main/java/com/tippus/MainActivity.java
@@ -3,6 +3,7 @@ package com.tippus;
 import android.app.Activity;
 import android.os.Bundle;
 import android.view.KeyEvent;
+import android.content.Intent;
 
 import com.facebook.react.LifecycleState;
 import com.facebook.react.ReactInstanceManager;
@@ -12,15 +13,21 @@ import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
 import com.github.xinthink.rnmk.ReactMaterialKitPackage;
 
+import com.magus.fblogin.FacebookLoginPackage;
+
 public class MainActivity extends Activity implements DefaultHardwareBackBtnHandler {
 
     private ReactInstanceManager mReactInstanceManager;
     private ReactRootView mReactRootView;
 
+    private FacebookLoginPackage mFacebookLoginPackage;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mReactRootView = new ReactRootView(this);
+
+        mFacebookLoginPackage = new FacebookLoginPackage(this);
 
         mReactInstanceManager = ReactInstanceManager.builder()
                 .setApplication(getApplication())
@@ -28,6 +35,9 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
                 .setJSMainModuleName("index.android")
                 .addPackage(new MainReactPackage())
                 .addPackage(new ReactMaterialKitPackage())
+
+                .addPackage(mFacebookLoginPackage)
+
                 .setUseDeveloperSupport(BuildConfig.DEBUG)
                 .setInitialLifecycleState(LifecycleState.RESUMED)
                 .build();
@@ -76,5 +86,12 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
         if (mReactInstanceManager != null) {
             mReactInstanceManager.onResume(this);
         }
+    }
+
+    @Override
+    public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        mFacebookLoginPackage.handleActivityResult(requestCode, resultCode, data);
     }
 }

--- a/tippus/android/app/src/main/res/values/strings.xml
+++ b/tippus/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">tippus</string>
+    <string name="fb_app_id">914216975336412</string>
 </resources>

--- a/tippus/android/settings.gradle
+++ b/tippus/android/settings.gradle
@@ -4,3 +4,6 @@ include ':app'
 
 include ':RNMaterialKit'
 project(':RNMaterialKit').projectDir = file('../node_modules/react-native-material-kit/android')
+
+include ':react-native-facebook-login'
+project(':react-native-facebook-login').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-facebook-login/android')

--- a/tippus/package.json
+++ b/tippus/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "react-native": "^0.13.2",
     "react-native-autocomplete": "^0.1.1",
+    "react-native-facebook-login": "^0.6.2",
     "react-native-material-kit": "^0.2.2",
     "react-native-navigation-drawer": "^1.2.2"
   }

--- a/tippus/scenes/login.js
+++ b/tippus/scenes/login.js
@@ -3,6 +3,7 @@
 var React = require('react-native');
 var MK = require('react-native-material-kit');
 var appStyles = require('../styles');
+var {FBLoginManager, FBLogin} = require('react-native-facebook-login/android');
 
 var {
   StyleSheet,
@@ -18,6 +19,7 @@ const {
   MKButton,
   mdl,
 } = MK;
+
 
 // TODO: investigate themes... would make coloring easier
 // customize the material design theme
@@ -62,33 +64,6 @@ const LoginButton = MKButton.coloredButton()
   // .withShadowOffset({width:0, height:2})
   // .withShadowOpacity(.7)
   // .withShadowColor('black')
-  .build();
-
-const FacebookLoginButton = MKButton.coloredButton()
-  .withText('Log in with Facebook')
-  // .withStyle(
-  //   {backgroundColor: '#3B5998'}
-  // )
-  // .withOnPress(() => {
-  //   console.log('Facebook Login button pressed!');
-  //   // for local dev, you will want to replace this with your IP and port +/rn/auth/facebook
-  //   fetch("http://tipp-us-staging.herokuapp.com/rn/auth/facebook", {
-  //     method: 'get',
-  //     headers: {
-  //       'Accept': 'application/json',
-  //       'Content-Type': 'application/json'
-  //     },
-  //     credentials: 'same-origin',
-  //   }).then(function(response) {
-  //     //Response from logging in
-  //     console.log('we got a reponse:', response);
-  //     return response.json();      
-  //   }, function(err) {console.log(err)})
-  //   .then(function(jsonRes) {
-  //     GLOBAL.user = jsonRes;
-  //     console.log(GLOBAL.user);
-  //   });
-  // })
   .build();
 
 const EmailInput = MKTextField.textfieldWithFloatingLabel()
@@ -145,6 +120,27 @@ var Login = React.createClass({
     })
     .done();
   },
+  onFacebookLogin: function(fbObj) {
+    // console.log(fbObj);
+    // for local dev, you will want to replace this with your IP and port +/rn/login/artist
+    fetch('http://' + GLOBAL.url + '/rn/auth/facebook', {
+      method: 'post',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      credentials: 'same-origin',
+      body: JSON.stringify({
+        facebookId: fbObj.profile.id,
+      }),
+    }).then(function(response) {
+      return response.json();      
+    }, function(err) {console.log(err);})
+    .then(function(jsonRes) {
+      GLOBAL.user = jsonRes;
+      console.log(GLOBAL.user);
+    });
+  },
   render: function() {
     return (
       <View style={styles.container}>
@@ -164,7 +160,11 @@ var Login = React.createClass({
         </View>
         <LoginButton 
           onPress={this.loginSubmit} />
-        <FacebookLoginButton />
+        <FBLogin
+          onLogin={this.onFacebookLogin}
+          onLogout={function(e){console.log(e)}}
+          onCancel={function(e){console.log(e)}}
+          onPermissionsMissing={function(e){console.log(e)}} />
       </View>
     );
   },

--- a/tippus/scenes/login.js
+++ b/tippus/scenes/login.js
@@ -139,7 +139,8 @@ var Login = React.createClass({
     .then(function(jsonRes) {
       GLOBAL.user = jsonRes;
       console.log(GLOBAL.user);
-    });
+    })
+    .done();
   },
   render: function() {
     return (

--- a/tippus/scenes/signup.js
+++ b/tippus/scenes/signup.js
@@ -191,7 +191,8 @@ var Signup = React.createClass({
     .then(function(jsonRes) {
       GLOBAL.user = jsonRes;
       console.log(GLOBAL.user);
-    });
+    })
+    .done();
   },
   render: function() {
     return (

--- a/tippus/scenes/signup.js
+++ b/tippus/scenes/signup.js
@@ -3,6 +3,7 @@
 var React = require('react-native');
 var MK = require('react-native-material-kit');
 var appStyles = require('../styles');
+var {FBLoginManager, FBLogin} = require('react-native-facebook-login/android');
 
 var {
   StyleSheet,
@@ -171,6 +172,27 @@ var Signup = React.createClass({
       .done();
     }
   },
+  onFacebookSignup: function(fbObj) {
+    // console.log(fbObj);
+    // for local dev, you will want to replace this with your IP and port +/rn/login/artist
+    fetch('http://' + GLOBAL.url + '/rn/auth/facebook', {
+      method: 'post',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      credentials: 'same-origin',
+      body: JSON.stringify({
+        facebookId: fbObj.profile.id,
+      }),
+    }).then(function(response) {
+      return response.json();      
+    }, function(err) {console.log(err);})
+    .then(function(jsonRes) {
+      GLOBAL.user = jsonRes;
+      console.log(GLOBAL.user);
+    });
+  },
   render: function() {
     return (
       <View style={styles.container}>
@@ -195,8 +217,12 @@ var Signup = React.createClass({
           </View>
         </View>
         <SignupButton 
-          onPress={this.signupSubmit}/>
-        <FacebookSignupButton />
+          onPress={this.signupSubmit} />
+        <FBLogin
+          onLogin={this.onFacebookSignup}
+          onLogout={function(e){console.log(e)}}
+          onCancel={function(e){console.log(e)}}
+          onPermissionsMissing={function(e){console.log(e)}} />
       </View>
     );
   },


### PR DESCRIPTION
- this was achieved with the react-native-facebook-login npm module
  and an open PR that has not been merged yet.
- react-native-facebook-login has been added to the tippus package.json
  but until the PR is merged it will have to be manually replaced with our
  version
- currently uses facebook id which is apparently different for a user
  depending on what app the request comes from, so for now the artist accounts
  that are created are not linked between webapp and react-native. We
  should be able to fix this by using email or another unique id
  returned from facebook auth.
